### PR TITLE
Prevents Duplicate Parties

### DIFF
--- a/proportional-representation.py
+++ b/proportional-representation.py
@@ -61,9 +61,13 @@ def main():
         while True:
             try:
                 party = str(input("Name of Party #" + str(x + 1) + ": "))
-                break
+                if not party in quota:
+                    break
+                else:
+                    print("The name of a party must be unique!")
+            
             except ValueError:
-                print("The name of a party has cannot be empty!")
+                print("The name of a party cannot be empty!")
 
         while True:
             try:


### PR DESCRIPTION
If the user attempts to add a party that they have already added it will print an error and request that they enter the party name again. Do keep in mind however that it is case sensitive, meaning "Greg's Party" is different from "Greg's party".